### PR TITLE
update binrpc version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.18
 
     - name: Prepare 
       run: make promu

--- a/.promu.yml
+++ b/.promu.yml
@@ -1,6 +1,6 @@
 verbose: true
 go:
-    version: 1.17
+    version: 1.18
     cgo: false
 repository:
     path: github.com/pascomnet/kamailio_exporter

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/pascomnet/kamailio_exporter
 
-go 1.17
+go 1.18
 
 require (
-	github.com/florentchauveau/go-kamailio-binrpc/v2 v2.0.2
+	github.com/florentchauveau/go-kamailio-binrpc/v3 v3.2.0
 	github.com/prometheus/client_golang v1.12.1
 	github.com/sirupsen/logrus v1.8.1
 	gopkg.in/urfave/cli.v1 v1.20.0
@@ -14,7 +14,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/florentchauveau/go-kamailio-binrpc/v2 v2.0.2 h1:CzW5mJEym/4FVLux93cW7Pj39sTp8rOrA+RNmKwXyRs=
-github.com/florentchauveau/go-kamailio-binrpc/v2 v2.0.2/go.mod h1:0PkOeQTKhwmcZ1wzRfccfEsQvHEsxm4N4lA85cITGQ4=
+github.com/florentchauveau/go-kamailio-binrpc/v3 v3.2.0 h1:0IR+Ck/QKC9aIarfNVQdKzDZwF7OP8ekFM8M7ZHb6UY=
+github.com/florentchauveau/go-kamailio-binrpc/v3 v3.2.0/go.mod h1:6g5QZzU9yUJao66NQsR2G7Jbo5MU2s/GZWRbqx6lgNc=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -154,7 +154,6 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/statscollector.go
+++ b/statscollector.go
@@ -27,7 +27,7 @@ import (
 	"strconv"
 	"strings"
 
-	binrpc "github.com/florentchauveau/go-kamailio-binrpc/v2"
+	binrpc "github.com/florentchauveau/go-kamailio-binrpc/v3"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/urfave/cli.v1"


### PR DESCRIPTION
Metrics export was not always possible, due to a bug in the binrpc API, see https://github.com/florentchauveau/go-kamailio-binrpc/issues/12 

Therefore we updated to the latest version of binrpc and also updated our go version to go from 1.17 to 1.18