### PR TITLE
Fix custom kamailio metrics url handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ go 1.18
 require (
 	github.com/florentchauveau/go-kamailio-binrpc/v3 v3.2.0
 	github.com/prometheus/client_golang v1.12.1
+	github.com/prometheus/client_model v0.2.0
+	github.com/prometheus/common v0.32.1
 	github.com/sirupsen/logrus v1.8.1
 	gopkg.in/urfave/cli.v1 v1.20.0
 )
@@ -14,8 +16,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
-	github.com/prometheus/client_model v0.2.0 // indirect
-	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	golang.org/x/sys v0.0.0-20220317061510-51cd9980dadf // indirect
 	google.golang.org/protobuf v1.27.1 // indirect


### PR DESCRIPTION
Using `--customKamailioMetricsURL` currently is broken. It intermingles the http response of the configured url with the locally generated metrics response. 
Since composing multiple text based promhttp responses is non trivial this fix instead parses the response generated from the custom url endpoint into proper prometheus data structures and then passes it on to the prometheus client code to be remitted as part of the http response.